### PR TITLE
Implement basic trade journal

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,12 @@
             </label>
         </div>
 
+        <!-- Section Toggle -->
+        <div class="section-toggle">
+            <button type="button" id="calculatorTab" class="toggle-button active">Calculator</button>
+            <button type="button" id="journalTab" class="toggle-button">Trade Journal</button>
+        </div>
+
         <!-- Main Calculator Section -->
         <section class="calculator-section" data-section="calculator">
             <div class="grid">
@@ -97,6 +103,8 @@
             </div>
 
             <button type="button" id="clearButton" class="clear-button">Clear Calculator</button>
+
+            <button type="button" id="saveTradeButton" class="journal-button" disabled>Save Trade to Journal</button>
 
             <!-- Calculator Results -->
             <div class="calculator-output">
@@ -235,13 +243,35 @@
             </div>
         </section>
 
-        <!-- Journal Section Placeholder -->
+        <!-- Journal Section -->
         <section class="journal-section hidden" data-section="journal" aria-hidden="true">
             <h2 class="section-title">Trade Journal</h2>
-            <!-- Journal UI will be added here -->
-            <div class="journal-placeholder">
-                <p>Journal feature coming soon...</p>
+
+            <div class="journal-form">
+                <div class="input-group">
+                    <label class="input-label" for="journalSymbol">Symbol</label>
+                    <input type="text" id="journalSymbol" class="journal-input" placeholder="e.g. AAPL">
+                </div>
+                <div class="input-group">
+                    <label class="input-label" for="journalOutcome">Outcome</label>
+                    <select id="journalOutcome" class="journal-input">
+                        <option value="pending">Pending</option>
+                        <option value="win">Win</option>
+                        <option value="loss">Loss</option>
+                    </select>
+                </div>
+                <div class="input-group">
+                    <label class="input-label" for="journalNotes">Notes</label>
+                    <textarea id="journalNotes" class="journal-input" rows="3" placeholder="Optional notes"></textarea>
+                </div>
+                <div class="input-group">
+                    <button type="button" id="addJournalEntryButton" class="journal-button">Add Entry</button>
+                    <button type="button" id="exportJournalButton" class="journal-button">Export CSV</button>
+                </div>
             </div>
+
+            <div id="journalStats" class="journal-stats"></div>
+            <div id="journalList" class="journal-list"></div>
         </section>
 
         <!-- Footer -->

--- a/js/main.js
+++ b/js/main.js
@@ -24,13 +24,49 @@ class App {
         // Initialize journal (placeholder for now)
         this.journal.init();
 
-        // Set up any global event listeners
+        // Set up section toggle and global event listeners
+        this.setupSectionToggle();
         this.setupGlobalEvents();
 
         // Initial calculation
         this.calculator.calculate();
 
         console.log('📊 Stock Trading Calculator initialized');
+    }
+
+    setupSectionToggle() {
+        const sections = {
+            calculator: document.querySelector('.calculator-section'),
+            journal: document.querySelector('.journal-section')
+        };
+        const calculatorTab = document.getElementById('calculatorTab');
+        const journalTab = document.getElementById('journalTab');
+
+        if (calculatorTab) {
+            calculatorTab.addEventListener('click', () => this.state.setActiveSection('calculator'));
+        }
+        if (journalTab) {
+            journalTab.addEventListener('click', () => this.state.setActiveSection('journal'));
+        }
+
+        this.state.on('activeSectionChanged', ({ oldSection, newSection }) => {
+            if (sections[oldSection]) {
+                sections[oldSection].classList.add('hidden');
+                sections[oldSection].setAttribute('aria-hidden', 'true');
+            }
+            if (sections[newSection]) {
+                sections[newSection].classList.remove('hidden');
+                sections[newSection].setAttribute('aria-hidden', 'false');
+            }
+            const oldTab = document.getElementById(`${oldSection}Tab`);
+            const newTab = document.getElementById(`${newSection}Tab`);
+            if (oldTab) oldTab.classList.remove('active');
+            if (newTab) newTab.classList.add('active');
+        });
+
+        // Ensure initial visibility
+        const initial = this.state.ui.activeSection;
+        this.state.emit('activeSectionChanged', { oldSection: initial, newSection: initial });
     }
 
     setupGlobalEvents() {

--- a/styles.css
+++ b/styles.css
@@ -105,6 +105,33 @@ body {
     display: none;
 }
 
+.journal-form {
+    display: grid;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-lg);
+}
+
+.journal-form textarea.journal-input {
+    height: auto;
+}
+
+.journal-stats {
+    display: flex;
+    gap: var(--spacing-md);
+    flex-wrap: wrap;
+    margin-bottom: var(--spacing-md);
+}
+
+.journal-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.journal-list .journal-card {
+    margin-bottom: 0;
+}
+
 /* Calculator output grouping */
 .calculator-output {
     /* Groups results, info, and scenarios for better organization */
@@ -524,6 +551,40 @@ body.dark-mode .journal-section {
     display: flex;
     justify-content: center;
     margin-bottom: var(--spacing-lg);
+}
+
+/* Section toggle navigation */
+.section-toggle {
+    display: flex;
+    justify-content: center;
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-md);
+}
+
+.toggle-button {
+    background-color: #f3f4f6;
+    border: 1px solid #d1d5db;
+    border-radius: var(--border-radius);
+    padding: 7px var(--spacing-md);
+    font-size: 15px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.toggle-button.active {
+    background-color: var(--theme-color);
+    color: #fff;
+}
+
+body.dark-mode .toggle-button {
+    background-color: #374151;
+    border-color: #4b5563;
+    color: #e5e7eb;
+}
+
+body.dark-mode .toggle-button.active {
+    background-color: var(--theme-color);
+    color: #fff;
 }
 
 .theme-toggle {


### PR DESCRIPTION
## Summary
- add navigation for switching between calculator and journal
- enable saving trades to a new journal interface
- render journal entries and stats with export ability

## Testing
- `node -c js/journal.js`
- `node -c js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_684098c344fc8332b5eb80857b10a22d