### PR TITLE
Add multiple trim tracking & rebrand to Trade Journal

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -395,6 +395,14 @@ body {
     border-radius: 6px;
 }
 
+.trim-summary-header {
+    font-size: 14px;
+    color: #78350f;
+    margin-bottom: 10px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #fbbf24;
+}
+
 .trim-detail {
     display: flex;
     align-items: center;
@@ -669,6 +677,11 @@ body {
 [data-theme="dark"] .snapshot-trimmed-info {
     background: #78350f;
     border-color: #92400e;
+}
+
+[data-theme="dark"] .trim-summary-header {
+    color: #fef3c7;
+    border-bottom-color: #92400e;
 }
 
 [data-theme="dark"] .trim-detail {
@@ -2558,6 +2571,11 @@ body.steel-mode .snapshot-action-row {
 body.steel-mode .snapshot-trimmed-info {
     background: #78350f;
     border-color: #92400e;
+}
+
+body.steel-mode .trim-summary-header {
+    color: #fef3c7;
+    border-bottom-color: #92400e;
 }
 
 body.steel-mode .trim-detail {


### PR DESCRIPTION
**Core Features - Multiple Trim Support:**
- Trades can now be trimmed multiple times (not just once)
- Each trim captures: date, exit price, shares sold, and profit
- Tracks remaining shares after each trim
- Auto-closes position when all shares are sold
- First trim defaults to 5R target price (editable)
- Subsequent trims allow flexible scaling out

**Enhanced Trim Modal:**
- Real-time preview of trim impact (profit, remaining shares)
- Validates shares don't exceed remaining amount
- Shows "will close position" indicator when selling all shares
- Date picker defaults to today
- Live profit/loss calculation with per-share breakdown

**Trim History Display:**
- Shows complete trim history in snapshot cards
- Summary header: "X trims • Total P&L: $X,XXX"
- Each trim details: shares, price, date, profit
- Displays remaining shares for active positions
- Exit rule reminder for trimmed positions

**Rebranding - Snapshots → Trade Journal:**
- All UI text updated from "Snapshots" to "Journal" or "Trades"
- Button: "Save Snapshot" → "Add to Journal"
- Modal: "Manage Snapshots" → "📖 Trade Journal"
- Counts: "X snapshots" → "X trades"
- All toast messages and confirmations updated
- Maintains backward compatibility with existing data

**Trade Lifecycle:**
1. Open → Trim Position → Status: Trimmed
2. Trimmed → Add Another Trim → Still Trimmed (if shares remain)
3. Trimmed → Sell All Remaining → Auto-closed with total P&L

🎨 Generated with [Claude Code](https://claude.com/claude-code)