### PR TITLE
Fix trim error message styling - show in red instead of green

### DIFF
--- a/js/logbook-lite.js
+++ b/js/logbook-lite.js
@@ -1082,27 +1082,27 @@ function addTrimToSnapshot(snapshots, index, onUpdate, modal) {
 
     // Validation
     if (shares > remainingShares) {
+      preview.className = 'trim-preview error';
       preview.innerHTML = `
-        <div style="color: #dc2626;">
-          <h4>Error:</h4>
-          <p>Cannot sell more than ${remainingShares} remaining shares!</p>
-        </div>
+        <h4>Error:</h4>
+        <p>Cannot sell more than ${remainingShares} remaining shares!</p>
       `;
       confirmBtn.disabled = true;
       return;
     }
 
     if (shares <= 0 || price <= 0) {
+      preview.className = 'trim-preview error';
       preview.innerHTML = `
-        <div style="color: #dc2626;">
-          <h4>Error:</h4>
-          <p>Price and shares must be greater than 0</p>
-        </div>
+        <h4>Error:</h4>
+        <p>Price and shares must be greater than 0</p>
       `;
       confirmBtn.disabled = true;
       return;
     }
 
+    // Reset to success state
+    preview.className = 'trim-preview';
     confirmBtn.disabled = false;
 
     const willClose = newRemainingShares === 0;

--- a/styles.css
+++ b/styles.css
@@ -455,16 +455,29 @@ body {
     border-radius: 6px;
 }
 
+.trim-preview.error {
+    background: #fee2e2;
+    border-color: #dc2626;
+}
+
 .trim-preview h4 {
     margin: 0 0 8px 0;
     font-size: 14px;
     color: #065f46;
 }
 
+.trim-preview.error h4 {
+    color: #dc2626;
+}
+
 .trim-preview p {
     margin: 4px 0;
     font-size: 13px;
     color: #047857;
+}
+
+.trim-preview.error p {
+    color: #dc2626;
 }
 
 .input-hint {
@@ -705,12 +718,25 @@ body {
     border-color: #065f46;
 }
 
+[data-theme="dark"] .trim-preview.error {
+    background: #7f1d1d;
+    border-color: #dc2626;
+}
+
 [data-theme="dark"] .trim-preview h4 {
     color: #d1fae5;
 }
 
+[data-theme="dark"] .trim-preview.error h4 {
+    color: #fca5a5;
+}
+
 [data-theme="dark"] .trim-preview p {
     color: #a7f3d0;
+}
+
+[data-theme="dark"] .trim-preview.error p {
+    color: #fca5a5;
 }
 
 [data-theme="dark"] .input-hint {
@@ -2599,12 +2625,25 @@ body.steel-mode .trim-preview {
     border-color: #065f46;
 }
 
+body.steel-mode .trim-preview.error {
+    background: #7f1d1d;
+    border-color: #dc2626;
+}
+
 body.steel-mode .trim-preview h4 {
     color: #d1fae5;
 }
 
+body.steel-mode .trim-preview.error h4 {
+    color: #fca5a5;
+}
+
 body.steel-mode .trim-preview p {
     color: #a7f3d0;
+}
+
+body.steel-mode .trim-preview.error p {
+    color: #fca5a5;
 }
 
 body.steel-mode .input-hint {


### PR DESCRIPTION
- Added .trim-preview.error CSS class with red background/border
- Error messages now clearly distinguished from success preview
- Updated JavaScript to toggle error class on validation failures
- Added theme support (dark mode & steel gray) for error state
- Errors: red background (#fee2e2), red text (#dc2626)
- Success: keeps green background as before

🎨 Generated with [Claude Code](https://claude.com/claude-code)