### PR TITLE
Add open risk tracking and trim percentage preset buttons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -330,6 +330,40 @@ body {
     color: #6b7280;
 }
 
+/* Open Risk Banner */
+.open-risk-banner {
+    padding: 12px 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.open-risk-banner.risk-low {
+    background: #d1fae5;
+    color: #065f46;
+}
+
+.open-risk-banner.risk-medium {
+    background: #fef3c7;
+    color: #78350f;
+}
+
+.open-risk-banner.risk-high {
+    background: #fee2e2;
+    color: #991b1b;
+}
+
+.open-risk-banner .risk-icon {
+    font-size: 18px;
+}
+
+.open-risk-banner .risk-detail {
+    font-weight: normal;
+    opacity: 0.8;
+}
+
 /* Filter Bar */
 .snapshots-filter-bar {
     display: flex;
@@ -433,6 +467,12 @@ body {
     font-weight: 700 !important;
 }
 
+/* Highlight Risk % */
+.snapshot-risk-highlight {
+    color: #f59e0b !important;
+    font-weight: 700 !important;
+}
+
 /* Trim Modal Styles */
 .trim-summary {
     padding: 12px;
@@ -440,6 +480,38 @@ body {
     border-radius: 6px;
     margin-bottom: 16px;
 }
+
+.trim-percent-buttons {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+}
+
+.trim-percent-btn {
+    padding: 8px 16px;
+    background: white;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #374151;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.trim-percent-btn:hover {
+    background: #f3f4f6;
+    border-color: #9ca3af;
+}
+
+.trim-percent-btn.active {
+    background: #1CA1F2;
+    color: white;
+    border-color: #1CA1F2;
+}
+
+/* Trim Modal Styles */
 
 .trim-summary p {
     margin: 4px 0;
@@ -2013,6 +2085,24 @@ body.dark-mode .btn-primary:disabled {
     background: #6b7280;
 }
 
+/* Dark mode trim percent buttons */
+body.dark-mode .trim-percent-btn {
+    background: #374151;
+    border-color: #4b5563;
+    color: #e5e7eb;
+}
+
+body.dark-mode .trim-percent-btn:hover {
+    background: #4b5563;
+    border-color: #6b7280;
+}
+
+body.dark-mode .trim-percent-btn.active {
+    background: #1CA1F2;
+    color: white;
+    border-color: #1CA1F2;
+}
+
 /* ==========================================================================
    LOGBOOK LITE STYLES
    ========================================================================== */
@@ -2691,4 +2781,22 @@ body.steel-mode .modal-close:hover {
     background: #9ca3af;
     color: #2c2c2c;
     border-color: #d1d5db;
+}
+
+/* Steel mode trim percent buttons */
+body.steel-mode .trim-percent-btn {
+    background: #4c4c4c;
+    border-color: #5a5a5a;
+    color: #f9fafb;
+}
+
+body.steel-mode .trim-percent-btn:hover {
+    background: #5a5a5a;
+    border-color: #6b7280;
+}
+
+body.steel-mode .trim-percent-btn.active {
+    background: #60a5fa;
+    color: white;
+    border-color: #60a5fa;
 }


### PR DESCRIPTION
Features:
- Display total open risk % on main page trade count
- Add color-coded open risk banner in journal modal (green <2%, yellow 2-3%, red 3%+)
- Show risk % in individual trade cards (highlighted in orange)
- Add trim preset buttons (10%, 20%, 25%, 50%, All) for easier position trimming
- Custom shares input still available for manual entry
- Preset buttons highlight when active, clear on manual input
- Full theme support (Light, Dark, Steel Gray) for all new elements

UX Improvements:
- Traders can quickly see total portfolio risk before entering new positions
- Preset buttons speed up trim calculations vs manual math
- Visual warnings help prevent over-risking account

🤖 Generated with [Claude Code](https://claude.com/claude-code)